### PR TITLE
Fix #15 - Implement persistent storage of OAuth 2 clients in DB

### DIFF
--- a/powerauth-webauth-client/src/main/resources/application.properties
+++ b/powerauth-webauth-client/src/main/resources/application.properties
@@ -2,8 +2,8 @@
 powerauth.webauth.service.url=http://localhost:8080/powerauth-webauth
 powerauth.webauth.service.oauth.authorizeUrl=http://localhost:8080/powerauth-webauth/oauth/authorize
 powerauth.webauth.service.oauth.tokenUrl=http://localhost:8080/powerauth-webauth/oauth/token
-powerauth.webauth.service.oauth.clientId=foo
-powerauth.webauth.service.oauth.clientSecret=bar
+powerauth.webauth.service.oauth.clientId=democlient
+powerauth.webauth.service.oauth.clientSecret=changeme
 
 # Database Keep-Alive
 spring.datasource.test-while-idle=true


### PR DESCRIPTION
Authorization server data moved to JDBC data source, if we want to keep something in memory (e.g. tokens), we can revert this part

DDL script is below - do we want to add run the DDL using spring boot if tables don't exist?

```sql
create table oauth_client_details (
  client_id VARCHAR(256) PRIMARY KEY,
  resource_ids VARCHAR(256),
  client_secret VARCHAR(256),
  scope VARCHAR(256),
  authorized_grant_types VARCHAR(256),
  web_server_redirect_uri VARCHAR(256),
  authorities VARCHAR(256),
  access_token_validity INTEGER,
  refresh_token_validity INTEGER,
  additional_information VARCHAR(4096),
  autoapprove VARCHAR(256)
);

create table oauth_client_token (
  token_id VARCHAR(256),
  token LONG VARBINARY,
  authentication_id VARCHAR(256) PRIMARY KEY,
  user_name VARCHAR(256),
  client_id VARCHAR(256)
);


create table oauth_access_token (
  token_id VARCHAR(256),
  token LONG VARBINARY,
  authentication_id VARCHAR(256) PRIMARY KEY,
  user_name VARCHAR(256),
  client_id VARCHAR(256),
  authentication LONG VARBINARY,
  refresh_token VARCHAR(256)
);

create table oauth_refresh_token (
  token_id VARCHAR(256),
  token LONG VARBINARY,
  authentication LONG VARBINARY
);

create table oauth_code (
  code VARCHAR(255), 
  authentication LONG VARBINARY
);

insert into oauth_client_details (client_id, client_secret, scope, authorized_grant_types, additional_information, autoapprove) values ('democlient', 'changeme', 'profile', 'authorization_code', '{}', 'true');
```
