### PR TITLE
Implementation of Issue 20 - Create NextStep method to obtain all pending operations for given "userId"

### DIFF
--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/enumeration/OperationRequestType.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/enumeration/OperationRequestType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.nextstep.model.enumeration;
+
+/**
+ * Enum representing an operation request type.
+ *
+ * @author Roman Strobl
+ */
+public enum OperationRequestType {
+    /**
+     * Used when creating an operation.
+     */
+    CREATE,
+
+    /**
+     * Used when updating an operation.
+     */
+    UPDATE
+
+}

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/GetPendingOperationsRequest.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/GetPendingOperationsRequest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.nextstep.model.request;
+
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
+
+/**
+ * Request object used for querying of pending operations.
+ *
+ * @author Roman Strobl, roman.strobl@lime-company.eu
+ */
+public class GetPendingOperationsRequest {
+
+    private String userId;
+    private AuthMethod authMethod;
+
+    /**
+     * Get the user id.
+     *
+     * @return user id
+     */
+    public String getUserId() {
+        return userId;
+    }
+
+    /**
+     * Set the user id.
+     *
+     * @param userId user id
+     */
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    /**
+     * Get the @{link AuthMethod}.
+     *
+     * @return authentication method
+     */
+    public AuthMethod getAuthMethod() {
+        return authMethod;
+    }
+
+    /**
+     * Set the @{link AuthMethod}.
+     *
+     * @param authMethod authentication method
+     */
+    public void setAuthMethod(AuthMethod authMethod) {
+        this.authMethod = authMethod;
+    }
+}

--- a/powerauth-nextstep/pom.xml
+++ b/powerauth-nextstep/pom.xml
@@ -40,6 +40,10 @@
 			<version>0.15.0</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
@@ -16,12 +16,11 @@
 
 package io.getlime.security.powerauth.app.nextstep.controller;
 
+import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationEntity;
+import io.getlime.security.powerauth.app.nextstep.service.OperationPersistenceService;
+import io.getlime.security.powerauth.app.nextstep.service.StepResolutionService;
 import io.getlime.security.powerauth.lib.nextstep.model.base.Request;
 import io.getlime.security.powerauth.lib.nextstep.model.base.Response;
-import io.getlime.security.powerauth.lib.nextstep.model.entity.AuthStep;
-import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
-import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthResult;
-import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResult;
 import io.getlime.security.powerauth.lib.nextstep.model.request.CreateOperationRequest;
 import io.getlime.security.powerauth.lib.nextstep.model.request.GetOperationDetailRequest;
 import io.getlime.security.powerauth.lib.nextstep.model.request.UpdateOperationRequest;
@@ -29,6 +28,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.CreateOperation
 import io.getlime.security.powerauth.lib.nextstep.model.response.GetOperationDetailResponse;
 import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateOperationResponse;
 import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,80 +45,76 @@ import java.util.Date;
 @Controller
 public class OperationController {
 
+    private OperationPersistenceService operationPersistenceService;
+    private StepResolutionService stepResolutionService;
+
+    @Autowired
+    public OperationController(OperationPersistenceService operationPersistenceService,
+                               StepResolutionService stepResolutionService) {
+        this.operationPersistenceService = operationPersistenceService;
+        this.stepResolutionService = stepResolutionService;
+    }
+
     /**
      * Create a new operation with given name and data.
+     *
      * @param request Create operation request.
      * @return Create operation response.
      */
     @RequestMapping(value = "/operation", method = RequestMethod.POST)
-    public @ResponseBody Response<CreateOperationResponse> createOperation(@RequestBody Request<CreateOperationRequest> request) {
-        CreateOperationResponse response = new CreateOperationResponse();
-        response.setOperationId("40269145-d91f-4579-badd-c57fa1133239");
-        response.setResult(AuthResult.CONTINUE);
-        response.setTimestampCreated(new Date());
-        response.setTimestampExpires(new DateTime().plusMinutes(5).toDate());
+    public @ResponseBody
+    Response<CreateOperationResponse> createOperation(@RequestBody Request<CreateOperationRequest> request) {
+        // resolve response based on dynamic step definitions
+        CreateOperationResponse response = stepResolutionService.resolveNextStepResponse(request.getRequestObject());
 
-        AuthStep authStep = new AuthStep();
-        authStep.setAuthMethod(AuthMethod.USERNAME_PASSWORD_AUTH);
-        response.getSteps().add(authStep);
+        // persist new operation
+        operationPersistenceService.createOperation(request.getRequestObject(), response);
 
         return new Response<>(Response.Status.OK, response);
     }
 
     /**
      * Update operation with given ID with a previous authentication step result.
+     *
      * @param request Update operation request.
      * @return Update operation response.
      */
     @RequestMapping(value = "/operation", method = RequestMethod.PUT)
-    public @ResponseBody Response<UpdateOperationResponse> updateOperation(@RequestBody Request<UpdateOperationRequest> request) {
+    public @ResponseBody
+    Response<UpdateOperationResponse> updateOperation(@RequestBody Request<UpdateOperationRequest> request) {
+        // resolve response based on dynamic step definitions
+        UpdateOperationResponse response = stepResolutionService.resolveNextStepResponse(request.getRequestObject());
 
-        UpdateOperationRequest requestObject = request.getRequestObject();
+        // persist operation update
+        operationPersistenceService.updateOperation(request.getRequestObject(), response);
 
-        UpdateOperationResponse response = new UpdateOperationResponse();
-        response.setOperationId(requestObject.getOperationId());
-        response.setUserId(requestObject.getUserId());
-        response.setTimestampCreated(new Date());
-        response.setTimestampExpires(new DateTime().plusMinutes(5).toDate());
-
-        if (AuthStepResult.CONFIRMED.equals(requestObject.getAuthStepResult())) {
-
-            if (AuthMethod.USERNAME_PASSWORD_AUTH.equals(requestObject.getAuthMethod())) {
-                response.setResult(AuthResult.CONTINUE);
-                AuthStep authStep = new AuthStep();
-                authStep.setAuthMethod(AuthMethod.SHOW_OPERATION_DETAIL);
-                response.getSteps().add(authStep);
-            } else {
-                response.setResult(AuthResult.DONE);
-            }
-
-        } else if (AuthStepResult.CANCELED.equals(requestObject.getAuthStepResult())) {
-            response.setResult(AuthResult.FAILED);
-        } else {
-            response.setResult(AuthResult.CONTINUE);
-
-            AuthStep authStep = new AuthStep();
-            authStep.setAuthMethod(AuthMethod.USERNAME_PASSWORD_AUTH);
-            response.getSteps().add(authStep);
-        }
         return new Response<>(Response.Status.OK, response);
     }
 
     /**
      * Get detail of an operation with given ID.
+     *
      * @param request Get operation detail request.
      * @return Get operation detail response.
      */
     @RequestMapping(value = "/operation/detail", method = RequestMethod.POST)
-    public @ResponseBody Response<GetOperationDetailResponse> operationDetail(@RequestBody Request<GetOperationDetailRequest> request) {
+    public @ResponseBody
+    Response<GetOperationDetailResponse> operationDetail(@RequestBody Request<GetOperationDetailRequest> request) {
 
         GetOperationDetailRequest requestObject = request.getRequestObject();
 
         GetOperationDetailResponse response = new GetOperationDetailResponse();
-        response.setOperationId(requestObject.getOperationId());
-        response.setUserId("26");
-        response.setOperationData("{\"amount\":100,\"currency\":\"CZK\",\"to\":\"CZ12000012345678901234\"}");
-        response.setResult(AuthResult.DONE);
+
+        OperationEntity operation = operationPersistenceService.getOperation(requestObject.getOperationId());
+        if (operation == null) {
+            throw new IllegalArgumentException("Invalid operationId: " + requestObject.getOperationId());
+        }
+        response.setOperationId(operation.getOperationId());
+        response.setUserId(operation.getUserId());
+        response.setOperationData(operation.getOperationData());
+        if (operation.getResult() != null) {
+            response.setResult(operation.getResult());
+        }
         response.setTimestampCreated(new Date());
         response.setTimestampExpires(new DateTime().plusMinutes(5).toDate());
         return new Response<>(Response.Status.OK, response);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/exception/DefaultExceptionResolver.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/exception/DefaultExceptionResolver.java
@@ -41,7 +41,7 @@ public class DefaultExceptionResolver {
     public @ResponseBody Response<ErrorModel> handleDefaultException() {
         ErrorModel error = new ErrorModel();
         error.setCode(ErrorModel.Code.ERROR_GENERIC);
-        error.setMessage("Unknown Error");
+        error.setMessage("error.unknown");
         return new Response<>(Response.Status.ERROR, error);
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/OperationHistoryRepository.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/OperationHistoryRepository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.app.nextstep.repository;
+
+import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationHistoryEntity;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Component;
+
+/**
+ * CrudRepository for persistence of operation history.
+ *
+ * @author Roman Strobl
+ */
+@Component
+public interface OperationHistoryRepository extends CrudRepository<OperationHistoryEntity, OperationHistoryEntity.OperationHistoryKey> {
+
+    /**
+     * Finds the newest resultId for given operation.
+     *
+     * @param operationId id of an operation
+     * @return newest resultId
+     */
+    Long findMaxResultId(String operationId);
+
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/OperationRepository.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/OperationRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.app.nextstep.repository;
+
+import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationEntity;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Component;
+
+/**
+ * CrudRepository for persistence of operations.
+ *
+ * @author Roman Strobl
+ */
+@Component
+public interface OperationRepository extends CrudRepository<OperationEntity, String> {
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/OperationRepository.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/OperationRepository.java
@@ -19,6 +19,8 @@ import io.getlime.security.powerauth.app.nextstep.repository.model.entity.Operat
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 /**
  * CrudRepository for persistence of operations.
  *
@@ -26,4 +28,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public interface OperationRepository extends CrudRepository<OperationEntity, String> {
+
+    List<OperationEntity> findPendingOperationsForUser(String userId);
+
 }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/StepDefinitionRepository.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/StepDefinitionRepository.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.app.nextstep.repository;
+
+import io.getlime.security.powerauth.app.nextstep.repository.model.entity.StepDefinitionEntity;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * CrudRepository for persistence of step definitions.
+ *
+ * @author Roman Strobl
+ */
+@Component
+public interface StepDefinitionRepository extends CrudRepository<StepDefinitionEntity, Long> {
+
+    /**
+     * Finds all step definions for operation specified by its name.
+     *
+     * @param operationName name of the operation
+     * @return List of step definitions
+     */
+    List<StepDefinitionEntity> findStepDefinitionsForOperation(String operationName);
+
+    /**
+     * Finds all distict operation names.
+     *
+     * @return List of operation names
+     */
+    List<String> findDistinctOperationNames();
+
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationEntity.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.app.nextstep.repository.model.entity;
+
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthResult;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Entity which stores status of an operation, its parameters and last result.
+ *
+ * @author Roman Strobl
+ */
+@Entity
+@Table(name = "ns_operation")
+public class OperationEntity implements Serializable {
+
+    private static final long serialVersionUID = -8991119412441607003L;
+
+    @Id
+    @Column(name = "operation_id")
+    private String operationId;
+
+    @Column(name = "operation_name")
+    private String operationName;
+
+    @Column(name = "operation_data")
+    private String operationData;
+
+    @Column(name = "user_id")
+    private String userId;
+
+    @Column(name = "result")
+    @Enumerated(EnumType.STRING)
+    private AuthResult result;
+
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "operation")
+    private List<OperationHistoryEntity> operationHistory;
+
+    public String getOperationId() {
+        return operationId;
+    }
+
+    public void setOperationId(String operationId) {
+        this.operationId = operationId;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    public void setOperationName(String operationName) {
+        this.operationName = operationName;
+    }
+
+    public String getOperationData() {
+        return operationData;
+    }
+
+    public void setOperationData(String operationData) {
+        this.operationData = operationData;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public AuthResult getResult() {
+        return result;
+    }
+
+    public void setResult(AuthResult result) {
+        this.result = result;
+    }
+
+    public List<OperationHistoryEntity> getOperationHistory() {
+        return operationHistory;
+    }
+
+    public void setOperationHistory(List<OperationHistoryEntity> operationHistory) {
+        this.operationHistory = operationHistory;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        OperationEntity that = (OperationEntity) o;
+
+        return operationId != null ? operationId.equals(that.operationId) : that.operationId == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return operationId != null ? operationId.hashCode() : 0;
+    }
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationEntity.java
@@ -28,6 +28,9 @@ import java.util.List;
  */
 @Entity
 @Table(name = "ns_operation")
+@NamedQueries({
+        @NamedQuery(name = "OperationEntity.findPendingOperationsForUser", query = "SELECT o FROM OperationEntity o WHERE o.userId=?1 AND o.result='CONTINUE'")
+})
 public class OperationEntity implements Serializable {
 
     private static final long serialVersionUID = -8991119412441607003L;

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationHistoryEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationHistoryEntity.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.app.nextstep.repository.model.entity;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Entity which stores history for an operation including request and response data.
+ *
+ * @author Roman Strobl
+ */
+@Entity
+@Table(name = "ns_operation_history")
+@NamedQuery(name = "OperationHistoryEntity.findMaxResultId", query = "SELECT max(h.primaryKey.resultId) FROM OperationHistoryEntity h WHERE h.primaryKey.operationId=?1")
+public class OperationHistoryEntity implements Serializable {
+
+    private static final long serialVersionUID = 4536813173706547247L;
+
+    @EmbeddedId
+    private OperationHistoryKey primaryKey;
+
+    @Column(name = "request_auth_step_result")
+    private String requestAuthStepResult;
+
+    @Column(name = "request_auth_method")
+    private String requestAuthMethod;
+
+    @Column(name = "request_params")
+    private String requestParams;
+
+    @Column(name = "response_result")
+    private String responseResult;
+
+    @Column(name = "response_steps")
+    private String responseSteps;
+
+    @Column(name = "response_timestamp_created")
+    private Date responseTimestampCreated;
+
+    @Column(name = "response_timestamp_expires")
+    private Date responseTimestampExpires;
+
+    @ManyToOne
+    @JoinColumn(name = "operation_id", insertable = false, updatable = false)
+    private OperationEntity operation;
+
+    public OperationHistoryEntity() {
+    }
+
+    public OperationHistoryEntity(String operationId, Long resultId) {
+        primaryKey = new OperationHistoryKey(operationId, resultId);
+    }
+
+    public OperationHistoryKey getPrimaryKey() {
+        return primaryKey;
+    }
+
+    public void setPrimaryKey(OperationHistoryKey primaryKey) {
+        this.primaryKey = primaryKey;
+    }
+
+    public String getRequestAuthStepResult() {
+        return requestAuthStepResult;
+    }
+
+    public void setRequestAuthStepResult(String requestAuthStepResult) {
+        this.requestAuthStepResult = requestAuthStepResult;
+    }
+
+    public String getRequestAuthMethod() {
+        return requestAuthMethod;
+    }
+
+    public void setRequestAuthMethod(String requestAuthMethod) {
+        this.requestAuthMethod = requestAuthMethod;
+    }
+
+    public String getRequestParams() {
+        return requestParams;
+    }
+
+    public void setRequestParams(String requestParams) {
+        this.requestParams = requestParams;
+    }
+
+    public String getResponseResult() {
+        return responseResult;
+    }
+
+    public void setResponseResult(String responseResult) {
+        this.responseResult = responseResult;
+    }
+
+    public String getResponseSteps() {
+        return responseSteps;
+    }
+
+    public void setResponseSteps(String responseSteps) {
+        this.responseSteps = responseSteps;
+    }
+
+    public Date getResponseTimestampCreated() {
+        return responseTimestampCreated;
+    }
+
+    public void setResponseTimestampCreated(Date responseTimestampCreated) {
+        this.responseTimestampCreated = responseTimestampCreated;
+    }
+
+    public Date getResponseTimestampExpires() {
+        return responseTimestampExpires;
+    }
+
+    public void setResponseTimestampExpires(Date responseTimestampExpires) {
+        this.responseTimestampExpires = responseTimestampExpires;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        OperationHistoryEntity that = (OperationHistoryEntity) o;
+
+        return getPrimaryKey() != null ? getPrimaryKey().equals(that.getPrimaryKey()) : that.getPrimaryKey() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return getPrimaryKey() != null ? getPrimaryKey().hashCode() : 0;
+    }
+
+    @Embeddable
+    public static class OperationHistoryKey implements Serializable {
+
+        @Column(name = "operation_id")
+        private String operationId;
+
+        @Column(name = "result_id")
+        private Long resultId;
+
+        public OperationHistoryKey() {
+        }
+
+        public OperationHistoryKey(String operationId, Long resultId) {
+            this.operationId = operationId;
+            this.resultId = resultId;
+        }
+
+        public String getOperationId() {
+            return operationId;
+        }
+
+        public void setOperationId(String operationId) {
+            this.operationId = operationId;
+        }
+
+        public Long getResultId() {
+            return resultId;
+        }
+
+        public void setResultId(Long resultId) {
+            this.resultId = resultId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            OperationHistoryKey that = (OperationHistoryKey) o;
+
+            if (operationId != null ? !operationId.equals(that.operationId) : that.operationId != null) return false;
+            return resultId != null ? resultId.equals(that.resultId) : that.resultId == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = operationId != null ? operationId.hashCode() : 0;
+            result = 31 * result + (resultId != null ? resultId.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationHistoryEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationHistoryEntity.java
@@ -15,6 +15,10 @@
  */
 package io.getlime.security.powerauth.app.nextstep.repository.model.entity;
 
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthResult;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResult;
+
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Date;
@@ -35,16 +39,19 @@ public class OperationHistoryEntity implements Serializable {
     private OperationHistoryKey primaryKey;
 
     @Column(name = "request_auth_step_result")
-    private String requestAuthStepResult;
+    @Enumerated(EnumType.STRING)
+    private AuthStepResult requestAuthStepResult;
 
     @Column(name = "request_auth_method")
-    private String requestAuthMethod;
+    @Enumerated(EnumType.STRING)
+    private AuthMethod requestAuthMethod;
 
     @Column(name = "request_params")
     private String requestParams;
 
     @Column(name = "response_result")
-    private String responseResult;
+    @Enumerated(EnumType.STRING)
+    private AuthResult responseResult;
 
     @Column(name = "response_steps")
     private String responseSteps;
@@ -74,19 +81,19 @@ public class OperationHistoryEntity implements Serializable {
         this.primaryKey = primaryKey;
     }
 
-    public String getRequestAuthStepResult() {
+    public AuthStepResult getRequestAuthStepResult() {
         return requestAuthStepResult;
     }
 
-    public void setRequestAuthStepResult(String requestAuthStepResult) {
+    public void setRequestAuthStepResult(AuthStepResult requestAuthStepResult) {
         this.requestAuthStepResult = requestAuthStepResult;
     }
 
-    public String getRequestAuthMethod() {
+    public AuthMethod getRequestAuthMethod() {
         return requestAuthMethod;
     }
 
-    public void setRequestAuthMethod(String requestAuthMethod) {
+    public void setRequestAuthMethod(AuthMethod requestAuthMethod) {
         this.requestAuthMethod = requestAuthMethod;
     }
 
@@ -98,11 +105,11 @@ public class OperationHistoryEntity implements Serializable {
         this.requestParams = requestParams;
     }
 
-    public String getResponseResult() {
+    public AuthResult getResponseResult() {
         return responseResult;
     }
 
-    public void setResponseResult(String responseResult) {
+    public void setResponseResult(AuthResult responseResult) {
         this.responseResult = responseResult;
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/StepDefinitionEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/StepDefinitionEntity.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.app.nextstep.repository.model.entity;
+
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthResult;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResult;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.OperationRequestType;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+/**
+ * Entity used to define steps for dynamic step resolution.
+ *
+ * @author Roman Strobl
+ */
+@Entity
+@Table(name = "ns_step_definition")
+@NamedQueries({
+        @NamedQuery(name = "StepDefinitionEntity.findStepDefinitionsForOperation", query = "SELECT sd FROM StepDefinitionEntity sd WHERE sd.operationName=?1 ORDER BY sd.stepDefinitionId"),
+        @NamedQuery(name = "StepDefinitionEntity.findDistinctOperationNames", query = "SELECT DISTINCT(sd.operationName) FROM StepDefinitionEntity sd")
+})
+public class StepDefinitionEntity implements Serializable {
+
+    private static final long serialVersionUID = 1125553531017608411L;
+
+    @Id
+    @Column(name = "step_definition_id")
+    private Long stepDefinitionId;
+
+    @Column(name = "operation_name")
+    private String operationName;
+
+    @Column(name = "operation_type")
+    @Enumerated(EnumType.STRING)
+    private OperationRequestType operationType;
+
+    @Column(name = "request_auth_step_result")
+    @Enumerated(EnumType.STRING)
+    private AuthStepResult requestAuthStepResult;
+
+    @Column(name = "request_auth_method")
+    @Enumerated(EnumType.STRING)
+    private AuthMethod requestAuthMethod;
+
+    @Column(name = "response_priority")
+    private Long responsePriority;
+
+    @Column(name = "response_auth_method")
+    @Enumerated(EnumType.STRING)
+    private AuthMethod responseAuthMethod;
+
+    @Column(name = "response_result")
+    @Enumerated(EnumType.STRING)
+    private AuthResult responseResult;
+
+    public Long getStepDefinitionId() {
+        return stepDefinitionId;
+    }
+
+    public void setStepDefinitionId(Long stepDefinitionId) {
+        this.stepDefinitionId = stepDefinitionId;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    public void setOperationName(String operationName) {
+        this.operationName = operationName;
+    }
+
+    public OperationRequestType getOperationType() {
+        return operationType;
+    }
+
+    public void setOperationType(OperationRequestType operationType) {
+        this.operationType = operationType;
+    }
+
+    public AuthStepResult getRequestAuthStepResult() {
+        return requestAuthStepResult;
+    }
+
+    public void setRequestAuthStepResult(AuthStepResult requestAuthStepResult) {
+        this.requestAuthStepResult = requestAuthStepResult;
+    }
+
+    public AuthMethod getRequestAuthMethod() {
+        return requestAuthMethod;
+    }
+
+    public void setRequestAuthMethod(AuthMethod requestAuthMethod) {
+        this.requestAuthMethod = requestAuthMethod;
+    }
+
+    public Long getResponsePriority() {
+        return responsePriority;
+    }
+
+    public void setResponsePriority(Long responsePriority) {
+        this.responsePriority = responsePriority;
+    }
+
+    public AuthMethod getResponseAuthMethod() {
+        return responseAuthMethod;
+    }
+
+    public void setResponseAuthMethod(AuthMethod responseAuthMethod) {
+        this.responseAuthMethod = responseAuthMethod;
+    }
+
+    public AuthResult getResponseResult() {
+        return responseResult;
+    }
+
+    public void setResponseResult(AuthResult responseResult) {
+        this.responseResult = responseResult;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        StepDefinitionEntity that = (StepDefinitionEntity) o;
+
+        return stepDefinitionId != null ? stepDefinitionId.equals(that.stepDefinitionId) : that.stepDefinitionId == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return stepDefinitionId != null ? stepDefinitionId.hashCode() : 0;
+    }
+
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/IdGeneratorService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/IdGeneratorService.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.nextstep.service;
+
+import io.getlime.security.powerauth.app.nextstep.repository.OperationHistoryRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+/**
+ * This service is used for generating ids for entities used to persist operations and their history.
+ *
+ * @author Roman Strobl
+ */
+@Service
+public class IdGeneratorService {
+
+    private OperationHistoryRepository operationHistoryRepository;
+
+    public IdGeneratorService(OperationHistoryRepository operationHistoryRepository) {
+        this.operationHistoryRepository = operationHistoryRepository;
+    }
+
+    /**
+     * Generates random operationId using UUID.randomUUID().
+     *
+     * @return generated operationId
+     */
+    public String generateOperationId() {
+        return UUID.randomUUID().toString();
+    }
+
+    /**
+     * Generates a new id for for OperationHistory for given operation.
+     *
+     * @param operationId id specifying an operation
+     * @return generated id for OperationHistory
+     */
+    public synchronized Long generateOperationHistoryId(String operationId) {
+        Long maxId = operationHistoryRepository.findMaxResultId(operationId);
+        if (maxId == null) {
+            return 1L;
+        } else {
+            return maxId + 1;
+        }
+    }
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationPersistenceService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationPersistenceService.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.app.nextstep.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.getlime.security.powerauth.app.nextstep.repository.OperationHistoryRepository;
+import io.getlime.security.powerauth.app.nextstep.repository.OperationRepository;
+import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationEntity;
+import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationHistoryEntity;
+import io.getlime.security.powerauth.lib.nextstep.model.request.CreateOperationRequest;
+import io.getlime.security.powerauth.lib.nextstep.model.request.UpdateOperationRequest;
+import io.getlime.security.powerauth.lib.nextstep.model.response.CreateOperationResponse;
+import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateOperationResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * This service handles conversion of operation request/response objects into operation entities.
+ * Operation entities are persisted, so that they can be later retrieved from the database.
+ *
+ * @author Roman Strobl
+ */
+@Service
+public class OperationPersistenceService {
+
+    private ObjectMapper objectMapper;
+    private IdGeneratorService idGeneratorService;
+    private OperationRepository operationRepository;
+    private OperationHistoryRepository operationHistoryRepository;
+
+
+    @Autowired
+    public OperationPersistenceService(IdGeneratorService idGeneratorService, OperationRepository operationRepository,
+                                       OperationHistoryRepository operationHistoryRepository) {
+        this.objectMapper = new ObjectMapper();
+        this.idGeneratorService = idGeneratorService;
+        this.operationRepository = operationRepository;
+        this.operationHistoryRepository = operationHistoryRepository;
+    }
+
+    /**
+     * Converts a CreateOperationRequest and CreateOperationResponse into OperationEntity and OperationHistoryEntity.
+     * Both entities are persisted to store both the operation and its history in the database.
+     *
+     * @param request  create request received from the client
+     * @param response create response generated for the client
+     */
+    public void createOperation(CreateOperationRequest request, CreateOperationResponse response) {
+        OperationEntity operation = new OperationEntity();
+        operation.setOperationName(request.getOperationName());
+        operation.setOperationData(request.getOperationData());
+        operation.setOperationId(response.getOperationId());
+        operation.setResult(response.getResult());
+        operationRepository.save(operation);
+
+        OperationHistoryEntity operationHistory = new OperationHistoryEntity(operation.getOperationId(),
+                idGeneratorService.generateOperationHistoryId(operation.getOperationId()));
+        operationHistory.setResponseResult(response.getResult().toString());
+        try {
+            // Params and steps are saved as JSON for now - new entities would be required to store this data.
+            // We can add these entities later in case they are needed.
+            operationHistory.setRequestParams(objectMapper.writeValueAsString(request.getParams()));
+            operationHistory.setResponseSteps(objectMapper.writeValueAsString(response.getSteps()));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        operationHistory.setResponseTimestampCreated(response.getTimestampCreated());
+        operationHistory.setResponseTimestampExpires(response.getTimestampExpires());
+        operationHistoryRepository.save(operationHistory);
+    }
+
+    /**
+     * Converts an UpdateOperationRequest and UpdateOperationResponse into OperationEntity and OperationHistoryEntity.
+     * Both entities are persisted to update the status of processed operation as well as update its history.
+     *
+     * @param request  create request received from the client
+     * @param response create response generated for the client
+     */
+    public void updateOperation(UpdateOperationRequest request, UpdateOperationResponse response) {
+        OperationEntity operation = operationRepository.findOne(response.getOperationId());
+        operation.setUserId(request.getUserId());
+        operation.setResult(response.getResult());
+        operationRepository.save(operation);
+
+        OperationHistoryEntity operationHistory = new OperationHistoryEntity(operation.getOperationId(),
+                idGeneratorService.generateOperationHistoryId(operation.getOperationId()));
+        operationHistory.setRequestAuthMethod(request.getAuthMethod().toString());
+        operationHistory.setRequestAuthStepResult(request.getAuthStepResult().toString());
+        operationHistory.setResponseResult(response.getResult().toString());
+        try {
+            // Params and steps are saved as JSON for now - new entities would be required to store this data.
+            // We can add these entities later in case they are needed.
+            operationHistory.setRequestParams(objectMapper.writeValueAsString(request.getParams()));
+            operationHistory.setResponseSteps(objectMapper.writeValueAsString(response.getSteps()));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        operationHistory.setResponseTimestampCreated(response.getTimestampCreated());
+        operationHistory.setResponseTimestampExpires(response.getTimestampExpires());
+        operationHistoryRepository.save(operationHistory);
+    }
+
+    /**
+     * Retrieve an OperationEntity for given operationId from database.
+     *
+     * @param operationId id of an operation
+     * @return OperationEntity loaded from database
+     */
+    public OperationEntity getOperation(String operationId) {
+        return operationRepository.findOne(operationId);
+    }
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.app.nextstep.service;
+
+import io.getlime.security.powerauth.app.nextstep.repository.StepDefinitionRepository;
+import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationEntity;
+import io.getlime.security.powerauth.app.nextstep.repository.model.entity.StepDefinitionEntity;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.AuthStep;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthResult;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResult;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.OperationRequestType;
+import io.getlime.security.powerauth.lib.nextstep.model.request.CreateOperationRequest;
+import io.getlime.security.powerauth.lib.nextstep.model.request.UpdateOperationRequest;
+import io.getlime.security.powerauth.lib.nextstep.model.response.CreateOperationResponse;
+import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateOperationResponse;
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+/**
+ * This service performs dynamic resolution of the next steps. Step definitions are loaded during class initialization
+ * and are used to generate responses for incoming requests. Step definitions are filtered by request parameters
+ * and matching step definitions are returned as the list of next steps (including priorities in case more step
+ * definitions match the request).
+ *
+ * @author Roman Strobl
+ */
+@Service
+public class StepResolutionService {
+
+    private IdGeneratorService idGeneratorService;
+    private OperationPersistenceService operationPersistenceService;
+    private Map<String, List<StepDefinitionEntity>> stepDefinitionsPerOperation;
+
+    @Autowired
+    public StepResolutionService(StepDefinitionRepository stepDefinitionRepository, OperationPersistenceService operationPersistenceService,
+                                 IdGeneratorService idGeneratorService) {
+        this.operationPersistenceService = operationPersistenceService;
+        this.idGeneratorService = idGeneratorService;
+        stepDefinitionsPerOperation = new HashMap<>();
+        List<String> operationNames = stepDefinitionRepository.findDistinctOperationNames();
+        for (String operationName : operationNames) {
+            stepDefinitionsPerOperation.put(operationName, stepDefinitionRepository.findStepDefinitionsForOperation(operationName));
+        }
+    }
+
+    /**
+     * Resolves the next steps for given CreateOperationRequest.
+     *
+     * @param request request to create a new operation
+     * @return response with ordered list of next steps
+     */
+    public CreateOperationResponse resolveNextStepResponse(CreateOperationRequest request) {
+        CreateOperationResponse response = new CreateOperationResponse();
+        response.setOperationId(idGeneratorService.generateOperationId());
+        // AuthStepResult and AuthMethod are not available when creating the operation, null values are used to ignore them
+        List<StepDefinitionEntity> stepDefinitions = filterSteps(request.getOperationName(), OperationRequestType.CREATE, null, null);
+        response.getSteps().addAll(prepareAuthSteps(stepDefinitions));
+        response.setTimestampCreated(new Date());
+        response.setTimestampExpires(new DateTime().plusMinutes(5).toDate());
+        Set<AuthResult> allResults = new HashSet<>();
+        for (StepDefinitionEntity stepDef : stepDefinitions) {
+            allResults.add(stepDef.getResponseResult());
+        }
+        if (allResults.size() == 1) {
+            response.setResult(allResults.iterator().next());
+            return response;
+        }
+        throw new IllegalStateException("Next step could not be resolved for new operation.");
+    }
+
+    /**
+     * Resolves the next steps for given UpdateOperationRequest.
+     *
+     * @param request request to update an existing operation
+     * @return response with ordered list of next steps
+     */
+    public UpdateOperationResponse resolveNextStepResponse(UpdateOperationRequest request) {
+        OperationEntity operation = operationPersistenceService.getOperation(request.getOperationId());
+        UpdateOperationResponse response = new UpdateOperationResponse();
+        response.setOperationId(request.getOperationId());
+        response.setUserId(request.getUserId());
+        List<StepDefinitionEntity> stepDefinitions = filterSteps(operation.getOperationName(), OperationRequestType.UPDATE, request.getAuthStepResult(), request.getAuthMethod());
+        response.getSteps().addAll(prepareAuthSteps(stepDefinitions));
+        response.setTimestampCreated(new Date());
+        response.setTimestampExpires(new DateTime().plusMinutes(5).toDate());
+        Set<AuthResult> allResults = new HashSet<>();
+        for (StepDefinitionEntity stepDef : stepDefinitions) {
+            allResults.add(stepDef.getResponseResult());
+        }
+        if (allResults.size() == 1) {
+            response.setResult(allResults.iterator().next());
+            return response;
+        }
+        throw new IllegalStateException("Next step could not be resolved for update operation.");
+    }
+
+    /**
+     * Filters step definitions by given parameters and returns a list of step definitions which match the query.
+     *
+     * @param operationName  name of the operation
+     * @param operationType  type of the operation - CREATE/UPDATE
+     * @param authStepResult result of previous authentication step
+     * @param authMethod     authentication method of previous authentication step
+     * @return filtered list of steps
+     */
+    private List<StepDefinitionEntity> filterSteps(String operationName, OperationRequestType operationType, AuthStepResult authStepResult, AuthMethod authMethod) {
+        List<StepDefinitionEntity> stepDefinitions = stepDefinitionsPerOperation.get(operationName);
+        List<StepDefinitionEntity> filteredStepDefinitions = new ArrayList<>();
+        for (StepDefinitionEntity stepDef : stepDefinitions) {
+            if (operationType != null && !operationType.equals(stepDef.getOperationType())) {
+                // filter by operation type
+                continue;
+            }
+            if (authStepResult != null && !authStepResult.equals(stepDef.getRequestAuthStepResult())) {
+                // filter by AuthStepResult
+                continue;
+            }
+            if (authMethod != null && !authMethod.equals(stepDef.getRequestAuthMethod())) {
+                // filter by AuthMethod
+                continue;
+            }
+            filteredStepDefinitions.add(stepDef);
+        }
+        return filteredStepDefinitions;
+    }
+
+    /**
+     * Converts List<StepDefinitionEntity> into a List<AuthStep>.
+     *
+     * @param stepDefinitions step definitions to convert
+     * @return converted list of authentication steps
+     */
+    private List<AuthStep> prepareAuthSteps(List<StepDefinitionEntity> stepDefinitions) {
+        List<AuthStep> authSteps = new ArrayList<>();
+        for (StepDefinitionEntity stepDef : stepDefinitions) {
+            if (stepDef.getResponseAuthMethod() != null) {
+                AuthStep authStep = new AuthStep();
+                authStep.setAuthMethod(stepDef.getResponseAuthMethod());
+                authSteps.add(authStep);
+            }
+        }
+        return authSteps;
+    }
+
+}

--- a/powerauth-nextstep/src/main/resources/application.properties
+++ b/powerauth-nextstep/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+# Database Keep-Alive
+spring.datasource.test-while-idle=true
+spring.datasource.test-on-borrow=true
+spring.datasource.validation-query=SELECT 1
+# Database Configuration - MySQL
+spring.datasource.url=jdbc:mysql://localhost:3306/powerauth
+spring.datasource.username=powerauth
+spring.datasource.password=
+spring.datasource.driver-class-name=com.mysql.jdbc.Driver

--- a/powerauth-webauth-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/method/init/ApiController.java
+++ b/powerauth-webauth-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/method/init/ApiController.java
@@ -15,13 +15,13 @@
  */
 package io.getlime.security.powerauth.lib.webauth.authentication.method.init;
 
+import io.getlime.security.powerauth.lib.nextstep.model.entity.AuthStep;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.KeyValueParameter;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResult;
 import io.getlime.security.powerauth.lib.webauth.authentication.controller.AuthMethodController;
 import io.getlime.security.powerauth.lib.webauth.authentication.exception.AuthStepException;
 import io.getlime.security.powerauth.lib.webauth.authentication.method.init.model.request.InitOperationRequest;
 import io.getlime.security.powerauth.lib.webauth.authentication.method.init.model.response.InitOperationResponse;
-import io.getlime.security.powerauth.lib.nextstep.model.entity.AuthStep;
-import io.getlime.security.powerauth.lib.nextstep.model.entity.KeyValueParameter;
-import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResult;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -51,8 +51,11 @@ public class ApiController extends AuthMethodController<InitOperationRequest, In
     @RequestMapping(value = "/authenticate", method = RequestMethod.POST)
     public @ResponseBody InitOperationResponse register(@RequestBody InitOperationRequest request) {
         if (request.getOperationId() == null) {
-            String operationName = "login";
-            String operationData = null;
+
+            // TODO - data needs to be received via OAuth2 authorization - this is just for testing
+            // String operationName = "login";
+            String operationName = "authorize_payment";
+            String operationData = "{\"amount\":100,\"currency\":\"CZK\",\"to\":\"CZ12000012345678901234\"}";
             List<KeyValueParameter> params = new ArrayList<>();
             return initiateOperationWithName(operationName, operationData, params, new AuthResponseProvider() {
 

--- a/powerauth-webauth-authentication/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/service/AuthenticationManagementService.java
+++ b/powerauth-webauth-authentication/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/service/AuthenticationManagementService.java
@@ -86,7 +86,7 @@ public class AuthenticationManagementService {
      */
     public String updateAuthenticationWithUserId(String userId) {
         UserOperationAuthentication auth = getPendingUserAuthentication();
-        if (auth.getUserId() != null && userId != auth.getUserId()) {
+        if (auth.getUserId() != null && !userId.equals(auth.getUserId())) {
             return null;
         }
         if (auth.getOperationId() == null) {

--- a/powerauth-webauth-docs/sql/mysql/create_schema.sql
+++ b/powerauth-webauth-docs/sql/mysql/create_schema.sql
@@ -1,0 +1,85 @@
+DROP TABLE IF EXISTS ns_step_definition;
+DROP TABLE IF EXISTS ns_operation_history;
+DROP TABLE IF EXISTS ns_operation;
+DROP TABLE IF EXISTS oauth_code;
+DROP TABLE IF EXISTS oauth_refresh_token;
+DROP TABLE IF EXISTS oauth_access_token;
+DROP TABLE IF EXISTS oauth_client_token;
+DROP TABLE IF EXISTS oauth_client_details;
+
+CREATE TABLE oauth_client_details (
+  client_id               VARCHAR(256) PRIMARY KEY,
+  resource_ids            VARCHAR(256),
+  client_secret           VARCHAR(256),
+  scope                   VARCHAR(256),
+  authorized_grant_types  VARCHAR(256),
+  web_server_redirect_uri VARCHAR(256),
+  authorities             VARCHAR(256),
+  access_token_validity   INTEGER,
+  refresh_token_validity  INTEGER,
+  additional_information  VARCHAR(4096),
+  autoapprove             VARCHAR(256)
+);
+
+CREATE TABLE oauth_client_token (
+  token_id          VARCHAR(256),
+  token             LONG VARBINARY,
+  authentication_id VARCHAR(256) PRIMARY KEY,
+  user_name         VARCHAR(256),
+  client_id         VARCHAR(256)
+);
+
+
+CREATE TABLE oauth_access_token (
+  token_id          VARCHAR(256),
+  token             LONG VARBINARY,
+  authentication_id VARCHAR(256) PRIMARY KEY,
+  user_name         VARCHAR(256),
+  client_id         VARCHAR(256),
+  authentication    LONG VARBINARY,
+  refresh_token     VARCHAR(256)
+);
+
+CREATE TABLE oauth_refresh_token (
+  token_id       VARCHAR(256),
+  token          LONG VARBINARY,
+  authentication LONG VARBINARY
+);
+
+CREATE TABLE oauth_code (
+  code           VARCHAR(255),
+  authentication LONG VARBINARY
+);
+
+CREATE TABLE ns_operation (
+  operation_id   VARCHAR(256) PRIMARY KEY,
+  operation_name VARCHAR(32),
+  operation_data VARCHAR(4096),
+  user_id        VARCHAR(256),
+  result         VARCHAR(32)
+);
+
+CREATE TABLE ns_operation_history (
+  operation_id               VARCHAR(256),
+  result_id                  INTEGER,
+  request_auth_method        VARCHAR(32),
+  request_auth_step_result   VARCHAR(32),
+  request_params             VARCHAR(4096),
+  response_result            VARCHAR(32),
+  response_steps             VARCHAR(4096),
+  response_timestamp_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  response_timestamp_expires TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (operation_id, result_id),
+  FOREIGN KEY operation_fk (operation_id) REFERENCES ns_operation (operation_id)
+);
+
+CREATE TABLE ns_step_definition (
+  step_definition_id       INTEGER PRIMARY KEY,
+  operation_name           VARCHAR(32),
+  operation_type           VARCHAR(32),
+  request_auth_method      VARCHAR(32),
+  request_auth_step_result VARCHAR(32),
+  response_priority        INTEGER,
+  response_auth_method     VARCHAR(32),
+  response_result          VARCHAR(32)
+);

--- a/powerauth-webauth-docs/sql/mysql/initial_data.sql
+++ b/powerauth-webauth-docs/sql/mysql/initial_data.sql
@@ -1,0 +1,63 @@
+INSERT INTO oauth_client_details (client_id, client_secret, scope, authorized_grant_types, additional_information, autoapprove)
+VALUES ('democlient', 'changeme', 'profile', 'authorization_code', '{}', 'true');
+
+# login - init operation -> CONTINUE
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (1, 'login', 'CREATE', NULL, NULL, 1, 'USER_ID_ASSIGN', 'CONTINUE');
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (2, 'login', 'CREATE', NULL, NULL, 2, 'USERNAME_PASSWORD_AUTH', 'CONTINUE');
+
+# login - update operation - CONFIRMED -> DONE
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (3, 'login', 'UPDATE', 'USER_ID_ASSIGN', 'CONFIRMED', 1, NULL, 'DONE');
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (4, 'login', 'UPDATE', 'USERNAME_PASSWORD_AUTH', 'CONFIRMED', 1, NULL, 'DONE');
+
+# login - update operation - CANCELED -> FAILED
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (5, 'login', 'UPDATE', 'USER_ID_ASSIGN', 'CANCELED', 1, NULL, 'FAILED');
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (6, 'login', 'UPDATE', 'USERNAME_PASSWORD_AUTH', 'CANCELED', 1, NULL, 'FAILED');
+
+# login - update operation - FAILED -> CONTINUE
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (7, 'login', 'UPDATE', 'USER_ID_ASSIGN', 'FAILED', 1, 'USER_ID_ASSIGN', 'CONTINUE');
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (8, 'login', 'UPDATE', 'USERNAME_PASSWORD_AUTH', 'FAILED', 2, 'USERNAME_PASSWORD_AUTH', 'CONTINUE');
+
+# authorize_payment - init operation -> CONTINUE
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (9, 'authorize_payment', 'CREATE', NULL, NULL, 1, 'USER_ID_ASSIGN', 'CONTINUE');
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (10, 'authorize_payment', 'CREATE', NULL, NULL, 2, 'USERNAME_PASSWORD_AUTH', 'CONTINUE');
+
+# authorize_payment - update operation (login) - CONFIRMED -> CONTINUE
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (11, 'authorize_payment', 'UPDATE', 'USER_ID_ASSIGN', 'CONFIRMED', 1, 'SHOW_OPERATION_DETAIL', 'CONTINUE');
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES
+  (12, 'authorize_payment', 'UPDATE', 'USERNAME_PASSWORD_AUTH', 'CONFIRMED', 2, 'SHOW_OPERATION_DETAIL', 'CONTINUE');
+
+# authorize_payment - update operation (login) - CANCELED -> FAILED
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (13, 'authorize_payment', 'UPDATE', 'USER_ID_ASSIGN', 'CANCELED', 1, NULL, 'FAILED');
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (14, 'authorize_payment', 'UPDATE', 'USERNAME_PASSWORD_AUTH', 'CANCELED', 1, NULL, 'FAILED');
+
+# authorize_payment - update operation (login) - FAILED -> CONTINUE
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (15, 'authorize_payment', 'UPDATE', 'USER_ID_ASSIGN', 'FAILED', 1, 'USER_ID_ASSIGN', 'CONTINUE');
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (16, 'authorize_payment', 'UPDATE', 'USERNAME_PASSWORD_AUTH', 'FAILED', 2, 'USERNAME_PASSWORD_AUTH', 'CONTINUE');
+
+# authorize_payment - update operation (review operation) - CONFIRMED -> DONE (TBD token)
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (17, 'authorize_payment', 'UPDATE', 'SHOW_OPERATION_DETAIL', 'CONFIRMED', 1, NULL, 'DONE');
+
+# authorize_payment - update operation (review operation) - CANCELED -> FAILED
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (18, 'authorize_payment', 'UPDATE', 'SHOW_OPERATION_DETAIL', 'CANCELED', 1, NULL, 'FAILED');
+
+# authorize_payment - update operation (review operation) - FAILED -> CONTINUE
+INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)
+VALUES (19, 'authorize_payment', 'UPDATE', 'SHOW_OPERATION_DETAIL', 'FAILED', 1, 'SHOW_OPERATION_DETAIL', 'CONTINUE');

--- a/powerauth-webauth/src/main/js/components/operation.js
+++ b/powerauth-webauth/src/main/js/components/operation.js
@@ -13,18 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { connect } from 'react-redux';
-
+import React from "react";
+import {connect} from "react-redux";
 // Actions
-import { getOperationData, authenticate } from '../actions/showOperationDataActions'
-
+import {authenticate, getOperationData} from "../actions/showOperationDataActions";
 // Components
-import { Button, FormGroup } from 'react-bootstrap';
-import Spinner from 'react-spin';
-
+import {Button, FormGroup} from "react-bootstrap";
 // i18n
-import {FormattedMessage} from 'react-intl';
+import {FormattedMessage} from "react-intl";
 
 /**
  * Operation component displays the operation data to the user.
@@ -59,10 +55,11 @@ export default class OperationDetail extends React.Component {
                         {this.props.context.data}
                     </FormGroup>
                     <FormGroup>
-                        <Button bsSize="lg" type="submit" bsStyle="success" block><FormattedMessage id="login.signIn"/></Button>
+                        <Button bsSize="lg" type="submit" bsStyle="success" block><FormattedMessage
+                            id="operation.confirm"/></Button>
                     </FormGroup>
                     <FormGroup>
-                        <a href="./authenticate/cancel"><FormattedMessage id="login.cancel"/></a>
+                        <a href="./authenticate/cancel"><FormattedMessage id="operation.cancel"/></a>
                     </FormGroup>
                 </form>
             </div>

--- a/powerauth-webauth/src/main/js/dispatcher/dispatcher.js
+++ b/powerauth-webauth/src/main/js/dispatcher/dispatcher.js
@@ -17,27 +17,33 @@
 export function dispatchAction(dispatch, response) {
     if (response.data.next.length > 0) {
         if (response.data.result === "CONFIRMED") {
-            var method = response.data.next[0];
-            switch (method.authMethod) {
-                case "USERNAME_PASSWORD_AUTH": {
-                    dispatch({
-                        type: "SHOW_SCREEN_LOGIN",
-                        payload: {
-                            loading: false,
-                            error: false,
-                            message: "login.pleaseLogIn"
-                        }
-                    });
-                    break;
-                }
-                case "SHOW_OPERATION_DETAIL": {
-                    dispatch({
-                        type: "SHOW_SCREEN_OPERATION_DATA",
-                        payload: {
-                            data: ""
-                        }
-                    });
-                    break;
+            const next = response.data.next;
+            for (let key in next) {
+                switch (next[key].authMethod) {
+                    case "USER_ID_ASSIGN": {
+                        // TODO - implement USER_ID_ASSIGN, for now it is ignored
+                        break;
+                    }
+                    case "USERNAME_PASSWORD_AUTH": {
+                        dispatch({
+                            type: "SHOW_SCREEN_LOGIN",
+                            payload: {
+                                loading: false,
+                                error: false,
+                                message: "login.pleaseLogIn"
+                            }
+                        });
+                        break;
+                    }
+                    case "SHOW_OPERATION_DETAIL": {
+                        dispatch({
+                            type: "SHOW_SCREEN_OPERATION_DATA",
+                            payload: {
+                                data: ""
+                            }
+                        });
+                        break;
+                    }
                 }
             }
         } else if (response.data.result === "FAILED") {

--- a/powerauth-webauth/src/main/resources/static/resources/messages_cs.properties
+++ b/powerauth-webauth/src/main/resources/static/resources/messages_cs.properties
@@ -2,6 +2,7 @@ error.authPage = Nelze zobrazit autentizační stránku.
 error.sessionExpired = Vaše relace byla ukončena.
 error.sessionTerminated = Relace byla ukončena
 error.invalidRequest = Žádost není korektní
+error.unknown=Nastala neznámá chyba
 login.signIn = Přihlásit se
 login.cancel = Zrušit
 login.loginNumber = Přihlašovací číslo

--- a/powerauth-webauth/src/main/resources/static/resources/messages_cs.properties
+++ b/powerauth-webauth/src/main/resources/static/resources/messages_cs.properties
@@ -17,4 +17,6 @@ login.username.long\ login.password.long = Uživatelské jméno i heslo jsou př
 login.password.empty\ login.username.long = Uživatelské jméno je příliš dlouhé, vyplňte heslo
 login.username.empty\ login.password.long = Vyplňte uživatelské jméno, heslo je příliš dlouhé
 login.type.unsupported = Nepodporovaný typ autentizace
+operation.confirm=Potvrdit
+operation.cancel=Zrušit
 message.redirect = Probíhá přesměrování na původní aplikaci

--- a/powerauth-webauth/src/main/resources/static/resources/messages_en.properties
+++ b/powerauth-webauth/src/main/resources/static/resources/messages_en.properties
@@ -2,6 +2,7 @@ error.authPage = Unable to display authentication page.
 error.sessionExpired = Your session has expired.
 error.sessionTerminated = Session has been terminated
 error.invalidRequest = Invalid request
+error.unknown=Nastala neznámá chyba
 login.signIn = Sign In
 login.cancel = Cancel
 login.loginNumber = Login number

--- a/powerauth-webauth/src/main/resources/static/resources/messages_en.properties
+++ b/powerauth-webauth/src/main/resources/static/resources/messages_en.properties
@@ -17,4 +17,6 @@ login.username.long\ login.password.long = Supplied username and password are to
 login.password.empty\ login.username.long = Supplied username is too long, fill in the password
 login.username.empty\ login.password.long = Fill in the username, supplied password is too long
 login.type.unsupported = Unsupported authentication type
+operation.confirm=Confirm
+operation.cancel=Cancel
 message.redirect = You will be redirected back to the original application.


### PR DESCRIPTION
Note that the issue-20 branch is built on top of the issue-19 branch, so this pull request contains both issue-19 and issue-20 implementations.

This implementation added querying of pending operations for given userId on the Next Step server.

Remarks:
* Currently no ordering is performed, operations are returned "as they come". I can order the operations in case it would be useful.
* I can also filter out expired operations - right now all operations are returned.
