### PR TITLE
Implementation of #42 - Let's use WebSockets for push token refresh

### DIFF
--- a/powerauth-webauth-authentication-mtoken/pom.xml
+++ b/powerauth-webauth-authentication-mtoken/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>powerauth-push-client</artifactId>
             <version>0.16.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-messaging</artifactId>
+            <version>4.3.7.RELEASE</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/powerauth-webauth-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/mtoken/controller/MessageController.java
+++ b/powerauth-webauth-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/mtoken/controller/MessageController.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.webauth.authentication.mtoken.controller;
+
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthResult;
+import io.getlime.security.powerauth.lib.webauth.authentication.mtoken.model.request.WebSocketRegistrationRequest;
+import io.getlime.security.powerauth.lib.webauth.authentication.mtoken.model.response.WebSocketAuthorizationResponse;
+import io.getlime.security.powerauth.lib.webauth.authentication.mtoken.model.response.WebSocketRegistrationResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessageType;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Controller for WebSocket messages.
+ *
+ * @author Roman Strobl
+ */
+@Controller
+public class MessageController {
+
+    private final SimpMessagingTemplate websocket;
+    private final Map<String, String> websocketIdToSessionMap;
+
+    @Autowired
+    public MessageController(SimpMessagingTemplate websocket) {
+        this.websocket = websocket;
+        websocketIdToSessionMap = new HashMap<>();
+    }
+
+    /**
+     * Create a MessageHeaders object for session.
+     *
+     * @param sessionId WebSocket session ID
+     * @return MessageHeaders
+     */
+    private MessageHeaders createHeaders(String sessionId) {
+        SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);
+        headerAccessor.setSessionId(sessionId);
+        headerAccessor.setLeaveMutable(true);
+        return headerAccessor.getMessageHeaders();
+    }
+
+    /**
+     * Registration of WebSockets. WebSocket sessions are linked to operations for later authorization messages
+     * to the clients. When authorization is complete, the removeWebSocketSession(String operationId) method should
+     * be called to stop the tracking of given operation.
+     *
+     * @param headerAccessor      message headers
+     * @param registrationRequest request for registration of a new WebSocket client
+     */
+    @MessageMapping("/registration")
+    public void register(SimpMessageHeaderAccessor headerAccessor, WebSocketRegistrationRequest registrationRequest) {
+        String sessionId = headerAccessor.getSessionId();
+        websocketIdToSessionMap.put(registrationRequest.getWebSocketId(), sessionId);
+        WebSocketRegistrationResponse registrationResponse = new WebSocketRegistrationResponse();
+        registrationResponse.setWebSocketId(registrationRequest.getWebSocketId());
+        websocket.convertAndSendToUser(
+                sessionId, "/topic/registration", registrationResponse, createHeaders(sessionId));
+    }
+
+    /**
+     * Notification of clients about completed authorization.
+     *
+     * @param operationId operation ID
+     * @param authResult  authorization result
+     */
+    public void notifyAuthorizationComplete(String operationId, AuthResult authResult) {
+        final String webSocketId = generateWebSocketId(operationId);
+        final String sessionId = websocketIdToSessionMap.get(webSocketId);
+        WebSocketAuthorizationResponse authorizationResponse = new WebSocketAuthorizationResponse();
+        authorizationResponse.setWebSocketId(webSocketId);
+        authorizationResponse.setAuthResult(authResult);
+        if (sessionId != null) {
+            websocket.convertAndSendToUser(
+                    sessionId, "/topic/authorization", authorizationResponse, createHeaders(sessionId));
+        }
+    }
+
+    /**
+     * Generates a hash from operationId which is used as webSocketId.
+     *
+     * @param operationId operation ID
+     * @return webSocketId
+     */
+    public String generateWebSocketId(String operationId) {
+        try {
+            return DatatypeConverter.printHexBinary(
+                    MessageDigest.getInstance("MD5").digest(operationId.getBytes("UTF-8")));
+        } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Removes WebSocket session identified by operationId from session tracking.
+     *
+     * @param operationId operation ID
+     */
+    public void removeWebSocketSession(String operationId) {
+        websocketIdToSessionMap.remove(generateWebSocketId(operationId));
+    }
+
+}

--- a/powerauth-webauth-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/mtoken/model/request/WebSocketRegistrationRequest.java
+++ b/powerauth-webauth-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/mtoken/model/request/WebSocketRegistrationRequest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.webauth.authentication.mtoken.model.request;
+
+/**
+ * Request for registration of a WebSocket session.
+ *
+ * @author Roman Strobl
+ */
+public class WebSocketRegistrationRequest {
+
+    private String webSocketId;
+
+    public String getWebSocketId() {
+        return webSocketId;
+    }
+
+    public void setWebSocketId(String webSocketId) {
+        this.webSocketId = webSocketId;
+    }
+}

--- a/powerauth-webauth-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/mtoken/model/response/MobileTokenInitResponse.java
+++ b/powerauth-webauth-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/mtoken/model/response/MobileTokenInitResponse.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.webauth.authentication.mtoken.model.response;
+
+import io.getlime.security.powerauth.lib.webauth.authentication.base.AuthStepResponse;
+
+/**
+ * Response to the init step of mobile token authentication.
+ *
+ * @author Roman Strobl
+ */
+public class MobileTokenInitResponse extends AuthStepResponse {
+
+    private String webSocketId;
+
+    public String getWebSocketId() {
+        return webSocketId;
+    }
+
+    public void setWebSocketId(String webSocketId) {
+        this.webSocketId = webSocketId;
+    }
+}

--- a/powerauth-webauth-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/mtoken/model/response/WebSocketAuthorizationResponse.java
+++ b/powerauth-webauth-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/mtoken/model/response/WebSocketAuthorizationResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.webauth.authentication.mtoken.model.response;
+
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthResult;
+
+/**
+ * Authorization response object for sending result of an authorization via WebSockets.
+ *
+ * @author Roman Strobl
+ */
+public class WebSocketAuthorizationResponse {
+
+    private String webSocketId;
+    private AuthResult authResult;
+
+    public String getWebSocketId() {
+        return webSocketId;
+    }
+
+    public void setWebSocketId(String webSocketId) {
+        this.webSocketId = webSocketId;
+    }
+
+    public AuthResult getAuthResult() {
+        return authResult;
+    }
+
+    public void setAuthResult(AuthResult authResult) {
+        this.authResult = authResult;
+    }
+
+}

--- a/powerauth-webauth-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/mtoken/model/response/WebSocketRegistrationResponse.java
+++ b/powerauth-webauth-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/mtoken/model/response/WebSocketRegistrationResponse.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.webauth.authentication.mtoken.model.response;
+
+/**
+ * Response to registration of a new WebSocket session.
+ *
+ * @author Roman Strobl
+ */
+public class WebSocketRegistrationResponse {
+
+    private String webSocketId;
+
+    public String getWebSocketId() {
+        return webSocketId;
+    }
+
+    public void setWebSocketId(String webSocketId) {
+        this.webSocketId = webSocketId;
+    }
+}

--- a/powerauth-webauth/package.json
+++ b/powerauth-webauth/package.json
@@ -29,6 +29,8 @@
     "redux-thunk": "^2.2.0",
     "redux-promise-middleware": "^4.2.0",
     "webpack": "^2.3.2",
+    "sockjs-client": "^1.1.2",
+    "stompjs": "^2.3.3",
     "react-intl": "^2.3.0",
     "react-intl-redux": "^0.5.0"
   },

--- a/powerauth-webauth/pom.xml
+++ b/powerauth-webauth/pom.xml
@@ -49,6 +49,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-messaging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-websocket</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-messaging</artifactId>
+        </dependency>
 
         <!-- Other Dependencies -->
         <dependency>

--- a/powerauth-webauth/src/main/java/io/getlime/security/powerauth/app/webauth/configuration/SecurityConfiguration.java
+++ b/powerauth-webauth/src/main/java/io/getlime/security/powerauth/app/webauth/configuration/SecurityConfiguration.java
@@ -38,7 +38,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .httpBasic().disable()
                 .csrf().disable()
                 .antMatcher("/**").authorizeRequests()
-                .antMatchers("/", "/authenticate", "/authenticate/**", "/oauth/error",  "/api/**", "/pa/**", "/resources/**", "/ext-resources/**").permitAll()
+                .antMatchers("/", "/authenticate", "/authenticate/**", "/oauth/error", "/api/**", "/pa/**", "/resources/**", "/ext-resources/**", "/websocket/**").permitAll()
                 .anyRequest().authenticated()
                 .and().exceptionHandling()
                 .authenticationEntryPoint(new LoginUrlAuthenticationEntryPoint("/authenticate"));

--- a/powerauth-webauth/src/main/java/io/getlime/security/powerauth/app/webauth/configuration/WebSocketConfiguration.java
+++ b/powerauth-webauth/src/main/java/io/getlime/security/powerauth/app/webauth/configuration/WebSocketConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.app.webauth.configuration;
+
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.config.annotation.AbstractWebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+
+/**
+ * Configuration of WebSockets with a simple message broker.
+ *
+ * @author Roman Strobl
+ */
+@Component
+@EnableWebSocketMessageBroker
+public class WebSocketConfiguration extends AbstractWebSocketMessageBrokerConfigurer {
+
+    public static final String MESSAGE_PREFIX = "/topic";
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/websocket").setAllowedOrigins("*").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker(MESSAGE_PREFIX);
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/powerauth-webauth/src/main/java/io/getlime/security/powerauth/app/webauth/configuration/WebSocketSecurityConfiguration.java
+++ b/powerauth-webauth/src/main/java/io/getlime/security/powerauth/app/webauth/configuration/WebSocketSecurityConfiguration.java
@@ -1,0 +1,24 @@
+package io.getlime.security.powerauth.app.webauth.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.socket.AbstractSecurityWebSocketMessageBrokerConfigurer;
+
+/**
+ * Security configuration for WebSockets.
+ *
+ * @author Roman Strobl
+ */
+@Configuration
+public class WebSocketSecurityConfiguration extends AbstractSecurityWebSocketMessageBrokerConfigurer {
+
+    /**
+     * Same origin check is disabled, otherwise the WebServices do not work in the mobile token UI.
+     * TODO - investigate how to overcome this problem
+     *
+     * @return same origin check disabled
+     */
+    @Override
+    protected boolean sameOriginDisabled() {
+        return true;
+    }
+}

--- a/powerauth-webauth/src/main/js/actions/tokenActions.js
+++ b/powerauth-webauth/src/main/js/actions/tokenActions.js
@@ -4,7 +4,12 @@ import {dispatchAction, dispatchError} from "../dispatcher/dispatcher";
 export function init() {
     return function (dispatch) {
         axios.post("./api/auth/token/init", {}).then((response) => {
+            dispatch({
+                type: "SHOW_SCREEN_TOKEN",
+                payload: response.data
+            });
         }).catch((error) => {
+            console.log(error);
         })
     }
 }

--- a/powerauth-webauth/src/main/js/websocket-client.js
+++ b/powerauth-webauth/src/main/js/websocket-client.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const SockJS = require('sockjs-client');
+let stompClient;
+require('stompjs');
+
+/**
+ * Registration for WebSocket routes with callback functions called on incoming messages.
+ * @param registrations routes and callback functions
+ * @param Web Socket ID
+ */
+function register(registrations, webSocketId) {
+    const socket = SockJS('./websocket');
+    stompClient = Stomp.over(socket);
+    stompClient.connect({}, function (frame) {
+        registrations.forEach(function (registration) {
+            stompClient.subscribe(registration.route, registration.callback);
+        });
+        // registration of the client with given webSocketId to link WebSocket session and operation
+        const msg = {"webSocketId": webSocketId};
+        stompClient.send("/app/registration", {}, JSON.stringify(msg));
+    });
+}
+
+/**
+ * Sends a WebSocket message
+ * @param destination message destination
+ * @param params parameters, use {} for empty
+ * @param message text of the message as JSON
+ */
+function send(destination, params, message) {
+    stompClient.send(destination, params, message);
+}
+
+module.exports.register = register;
+module.exports.send = send;


### PR DESCRIPTION
I implemented the first version of WebSocket notifications for the mobile token step.

Remarks:
* 3s polling is still used as a fallback for authorization, so even if the message could not be sent from the server to the client, it's no big deal.
* WebSockets are used to notify the UI (the Token component) so that authenticate() method can be dispatched immediately, authentication still works the same as before but its trigger is faster in mobile token step thanks to WebSocket notification.

How does it work:
* During the /init phase of mtoken step a MobileTokenInitResponse object is returned which contains a generated webSocketId used during the WebSocket communication.
* The webSocketId is generated as an MD5 hash of operationId, so that we don't send operationId to the UI, however we can still link the webSocketId with operationId easily (for tracking sessions). The hashing algorithm can be changed easily in case we would want something more solid than MD5.
* The UI receives the webSocketId via the /init phase of mtoken step and it is transferred via store to the Token component.
* The Token component can now register the web service client with the webSocketId.
* MessageController receives a registration message with the webSocketId and stores the webSocketId into a map together with the WebSocket sessionId, which identifies the session (and is different from HTTP session).
* MessageController responds with a registration confirmation message, this completes the registration (for now we just log the event in browser console in the UI).
* The Token UI component keeps doing what it usually does - calling authorize() every 3s.
* The user confirms the mobile token step on the mobile device. The confirmation is sent to the /operation/authorize endpoint.
* The /operation/authorize endpoint updates the operation and now it also calls the MessageController.notifyAuthorizationComplete() method with known operationId.
* MessageController looks up the WebSocket session in map based on webSocketId (derived from the received operationId using its hash) and sends a WebSocket message to the UI through the correct WebSocket session.
* The UI receives the authorization message and bypasses the 3s timeout by calling authorize() method immediately. If it succeeds, the component state is updated to avoid calling authorize() from the regular 3s timeout.
* MobileTokenController takes care of obsolete WebSocket sessions by removing them using the MessageController.removeWebSocketSession() method. This removes them from the map of webSocketId->sessionId and needs to be done when authorization is finished.
* The WebSocket in the UI is automatically closed when user is redirected to another URL.

Caveats:
* I had to mock authorization confirmation from the mobile device, so the code is not 100% tested. Hopefully it will work.
* I had to introduce class WebSocketSecurityConfiguration and disable same origin check, otherwise I was getting Exception during registration of WebSockets, we should look into this.
* I still haven't seen it but theoretically there could be a duplicate call of authorize() in the UI when WebSocket call happens at the same time as the 3s timeout. But this can be easily prevented, I will look into this once we confirm current approach works.

Here is a screenshot of a log with successfull confirmation triggered using the /operation/authorize endpoint, sent via WebSockets. For now I kept some of the console.log() messages so that we can debug problems easily, we will remove those later.

![image](https://user-images.githubusercontent.com/26658588/27587877-6a4959d6-5b46-11e7-9f5c-aefd3fb21171.png)




