### PR TITLE
Fix #30: Priority is ignored in Next Step step definitions

### DIFF
--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationPersistenceService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationPersistenceService.java
@@ -30,7 +30,6 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.CreateOperation
 import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateOperationResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import sun.rmi.runtime.Log;
 
 import java.io.IOException;
 import java.util.ArrayList;


### PR DESCRIPTION
Added sorting by priority
Step definitions are checked for duplicate priorities