### PR TITLE
Fix #68: Allow custom operation ID while creating operation

### DIFF
--- a/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
+++ b/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
@@ -91,28 +91,31 @@ public class NextStepClient {
      * Calls the operation endpoint via POST method to create a new operation.
      *
      * @param operationName operation name
+     * @param operationId operation ID (optional)
      * @param operationData operation data
      * @param params        list of generic parameters
      * @return a Response with CreateOperationResponse object for OK status or ErrorModel for ERROR status
      */
-    public Response<CreateOperationResponse> createOperation(String operationName, String operationData, List<KeyValueParameter> params) throws NextStepServiceException {
-        return createOperation(operationName, operationData, null, params);
+    public Response<CreateOperationResponse> createOperation(String operationName, String operationId, String operationData, List<KeyValueParameter> params) throws NextStepServiceException {
+        return createOperation(operationName, operationId, operationData, null, params);
     }
 
     /**
      * Calls the operation endpoint via POST method to create a new operation.
      *
      * @param operationName operation name
+     * @param operationId operation ID (optional)
      * @param operationData operation data
      * @param displayDetails operation display details, such as title, message and displayable attributes
      * @param params        list of generic parameters
      * @return a Response with CreateOperationResponse object for OK status or ErrorModel for ERROR status
      */
-    public Response<CreateOperationResponse> createOperation(String operationName, String operationData, OperationDisplayDetails displayDetails, List<KeyValueParameter> params) throws NextStepServiceException {
+    public Response<CreateOperationResponse> createOperation(String operationName, String operationId, String operationData, OperationDisplayDetails displayDetails, List<KeyValueParameter> params) throws NextStepServiceException {
         try {
             // Exchange next step request with NextStep server.
             CreateOperationRequest request = new CreateOperationRequest();
             request.setOperationName(operationName);
+            request.setOperationId(operationId);
             request.setOperationData(operationData);
             request.setDisplayDetails(displayDetails);
             if (params != null) {

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/AuthMethodDetail.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/AuthMethodDetail.java
@@ -1,0 +1,37 @@
+package io.getlime.security.powerauth.lib.nextstep.model.entity;
+
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
+
+/**
+ * @author Roman Strobl, roman.strobl@lime-company.eu
+ */
+public class AuthMethodDetail {
+
+    private AuthMethod authMethod;
+    private Boolean hasUserInterface;
+    private String displayNameKey;
+
+    public AuthMethod getAuthMethod() {
+        return authMethod;
+    }
+
+    public void setAuthMethod(AuthMethod authMethod) {
+        this.authMethod = authMethod;
+    }
+
+    public Boolean getHasUserInterface() {
+        return hasUserInterface;
+    }
+
+    public void setHasUserInterface(Boolean hasUserInterface) {
+        this.hasUserInterface = hasUserInterface;
+    }
+
+    public String getDisplayNameKey() {
+        return displayNameKey;
+    }
+
+    public void setDisplayNameKey(String displayNameKey) {
+        this.displayNameKey = displayNameKey;
+    }
+}

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/CreateOperationRequest.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/CreateOperationRequest.java
@@ -29,6 +29,7 @@ import java.util.List;
 public class CreateOperationRequest {
 
     private String operationName;
+    private String operationId;
     private String operationData;
     private List<KeyValueParameter> params;
     private OperationDisplayDetails displayDetails;
@@ -54,6 +55,24 @@ public class CreateOperationRequest {
      */
     public void setOperationName(String operationName) {
         this.operationName = operationName;
+    }
+
+    /**
+     * Get the operation ID.
+     *
+     * @return Operation ID.
+     */
+    public String getOperationId() {
+        return operationId;
+    }
+
+    /**
+     * Set the operation ID.
+     *
+     * @param operationId operation ID, use null value in case operation ID should be generated.
+     */
+    public void setOperationId(String operationId) {
+        this.operationId = operationId;
     }
 
     /**

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/response/GetAuthMethodsResponse.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/response/GetAuthMethodsResponse.java
@@ -15,7 +15,7 @@
  */
 package io.getlime.security.powerauth.lib.nextstep.model.response;
 
-import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.AuthMethodDetail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +27,7 @@ import java.util.List;
  */
 public class GetAuthMethodsResponse {
 
-    private List<AuthMethod> authMethods;
+    private List<AuthMethodDetail> authMethods;
 
     /**
      * Default constructor.
@@ -36,11 +36,11 @@ public class GetAuthMethodsResponse {
         authMethods = new ArrayList<>();
     }
 
-    public List<AuthMethod> getAuthMethods() {
+    public List<AuthMethodDetail> getAuthMethods() {
         return authMethods;
     }
 
-    public void setAuthMethods(List<AuthMethod> authMethods) {
+    public void setAuthMethods(List<AuthMethodDetail> authMethods) {
         this.authMethods = authMethods;
     }
 }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.nextstep.controller;
+
+import io.getlime.security.powerauth.app.nextstep.service.AuthMethodService;
+import io.getlime.security.powerauth.lib.nextstep.model.base.Request;
+import io.getlime.security.powerauth.lib.nextstep.model.base.Response;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.AuthMethodDetail;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
+import io.getlime.security.powerauth.lib.nextstep.model.request.GetAuthMethodsRequest;
+import io.getlime.security.powerauth.lib.nextstep.model.request.UpdateAuthMethodRequest;
+import io.getlime.security.powerauth.lib.nextstep.model.response.GetAuthMethodsResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
+
+/**
+ * Controller class related to Next Step authentication methods and user preferences.
+ *
+ * @author Roman Strobl, roman.strobl@lime-company.eu
+ */
+@Controller
+public class AuthMethodController {
+
+    private AuthMethodService authMethodService;
+
+    @Autowired
+    public AuthMethodController(AuthMethodService authMethodService) {
+        this.authMethodService = authMethodService;
+    }
+
+    /**
+     * Get all authentication methods supported by Next Step server.
+     *
+     * @param request Get auth methods request. Use null userId in request.
+     * @return List of authentication methods wrapped in GetAuthMethodResponse.
+     */
+    @RequestMapping(value = "/auth-method/list", method = RequestMethod.POST)
+    public @ResponseBody
+    Response<GetAuthMethodsResponse> getAuthMethods(@RequestBody Request<GetAuthMethodsRequest> request) {
+        GetAuthMethodsRequest requestObject = request.getRequestObject();
+        String userId = requestObject.getUserId();
+        if (userId != null) {
+            throw new IllegalArgumentException("Parameter userId is not null in request object, however null value was expected.");
+        }
+        List<AuthMethodDetail> authMethods = authMethodService.listAuthMethods();
+        if (authMethods == null || authMethods.isEmpty()) {
+            throw new IllegalStateException("No authentication method is configured in Next Step server.");
+        }
+        GetAuthMethodsResponse response = new GetAuthMethodsResponse();
+        response.setAuthMethods(authMethods);
+        return new Response<>(Response.Status.OK, response);
+    }
+
+    /**
+     * Get all enabled authentication methods for given user.
+     *
+     * @param request Get auth methods request. Use non-null userId in request.
+     * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
+     */
+    @RequestMapping(value = "/user/auth-method/list", method = RequestMethod.POST)
+    public @ResponseBody
+    Response<GetAuthMethodsResponse> getAuthMethodsEnabledForUser(@RequestBody Request<GetAuthMethodsRequest> request) {
+        GetAuthMethodsRequest requestObject = request.getRequestObject();
+        String userId = requestObject.getUserId();
+        if (userId == null) {
+            throw new IllegalArgumentException("Parameter userId is null in request object.");
+        }
+        List<AuthMethodDetail> authMethods = authMethodService.listAuthMethodsEnabledForUser(userId);
+        GetAuthMethodsResponse response = new GetAuthMethodsResponse();
+        response.setAuthMethods(authMethods);
+        return new Response<>(Response.Status.OK, response);
+    }
+
+    /**
+     * Enable an authentication method for given user.
+     *
+     * @param request Update auth method request. Use non-null userId in request and specify authMethod.
+     * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
+     */
+    @RequestMapping(value = "/user/auth-method", method = RequestMethod.POST)
+    public @ResponseBody
+    Response<GetAuthMethodsResponse> enableAuthMethodForUser(@RequestBody Request<UpdateAuthMethodRequest> request) {
+        UpdateAuthMethodRequest requestObject = request.getRequestObject();
+        String userId = requestObject.getUserId();
+        if (userId == null) {
+            throw new IllegalArgumentException("Parameter userId is null in request object when enabling authentication method.");
+        }
+        AuthMethod authMethod = requestObject.getAuthMethod();
+        if (authMethod == null) {
+            throw new IllegalArgumentException("Parameter authMethod is null in request object when enabling authentication method.");
+        }
+        authMethodService.updateAuthMethodForUser(userId, authMethod, true);
+        List<AuthMethodDetail> authMethods = authMethodService.listAuthMethodsEnabledForUser(userId);
+        GetAuthMethodsResponse response = new GetAuthMethodsResponse();
+        response.setAuthMethods(authMethods);
+        return new Response<>(Response.Status.OK, response);
+    }
+
+    /**
+     * Disable an authentication method for given user.
+     *
+     * @param request Update auth method request. Use non-null userId in request and specify authMethod.
+     * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
+     */
+    @RequestMapping(value = "/user/auth-method", method = RequestMethod.DELETE)
+    public @ResponseBody
+    Response<GetAuthMethodsResponse> disableAuthMethodForUser(@RequestBody Request<UpdateAuthMethodRequest> request) {
+        UpdateAuthMethodRequest requestObject = request.getRequestObject();
+        String userId = requestObject.getUserId();
+        if (userId == null) {
+            throw new IllegalArgumentException("Parameter userId is null in request object when disabling authentication method.");
+        }
+        AuthMethod authMethod = requestObject.getAuthMethod();
+        if (authMethod == null) {
+            throw new IllegalArgumentException("Parameter authMethod is null in request object when disabling authentication method.");
+        }
+        authMethodService.updateAuthMethodForUser(userId, authMethod, false);
+        List<AuthMethodDetail> authMethods = authMethodService.listAuthMethodsEnabledForUser(userId);
+        GetAuthMethodsResponse response = new GetAuthMethodsResponse();
+        response.setAuthMethods(authMethods);
+        return new Response<>(Response.Status.OK, response);
+    }
+
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
@@ -17,22 +17,19 @@
 package io.getlime.security.powerauth.app.nextstep.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.getlime.security.powerauth.app.nextstep.configuration.NextStepServerConfiguration;
-import io.getlime.security.powerauth.app.nextstep.repository.AuthMethodRepository;
-import io.getlime.security.powerauth.app.nextstep.repository.model.entity.AuthMethodEntity;
 import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationEntity;
 import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationHistoryEntity;
 import io.getlime.security.powerauth.app.nextstep.service.OperationPersistenceService;
 import io.getlime.security.powerauth.app.nextstep.service.StepResolutionService;
-import io.getlime.security.powerauth.app.nextstep.service.UserPrefsService;
 import io.getlime.security.powerauth.lib.nextstep.model.base.Request;
 import io.getlime.security.powerauth.lib.nextstep.model.base.Response;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationDisplayDetails;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationHistory;
-import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
-import io.getlime.security.powerauth.lib.nextstep.model.request.*;
+import io.getlime.security.powerauth.lib.nextstep.model.request.CreateOperationRequest;
+import io.getlime.security.powerauth.lib.nextstep.model.request.GetOperationDetailRequest;
+import io.getlime.security.powerauth.lib.nextstep.model.request.GetPendingOperationsRequest;
+import io.getlime.security.powerauth.lib.nextstep.model.request.UpdateOperationRequest;
 import io.getlime.security.powerauth.lib.nextstep.model.response.CreateOperationResponse;
-import io.getlime.security.powerauth.lib.nextstep.model.response.GetAuthMethodsResponse;
 import io.getlime.security.powerauth.lib.nextstep.model.response.GetOperationDetailResponse;
 import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateOperationResponse;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,7 +46,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Controller class related to PowerAuth activation management.
+ * Controller class related to Next Step operations.
  *
  * @author Petr Dvorak
  */
@@ -58,19 +55,12 @@ public class OperationController {
 
     private OperationPersistenceService operationPersistenceService;
     private StepResolutionService stepResolutionService;
-    private NextStepServerConfiguration nextStepServerConfiguration;
-    private AuthMethodRepository authMethodRepository;
-    private UserPrefsService userPrefsService;
 
     @Autowired
     public OperationController(OperationPersistenceService operationPersistenceService,
-                               StepResolutionService stepResolutionService, NextStepServerConfiguration nextStepServerConfiguration,
-                               AuthMethodRepository authMethodRepository, UserPrefsService userPrefsService) {
+                               StepResolutionService stepResolutionService) {
         this.operationPersistenceService = operationPersistenceService;
         this.stepResolutionService = stepResolutionService;
-        this.nextStepServerConfiguration = nextStepServerConfiguration;
-        this.authMethodRepository = authMethodRepository;
-        this.userPrefsService = userPrefsService;
     }
 
     /**
@@ -204,103 +194,6 @@ public class OperationController {
             responseList.add(response);
         }
         return new Response<>(Response.Status.OK, responseList);
-    }
-
-    /**
-     * Get all authentication methods supported by Next Step server.
-     *
-     * @param request Get auth methods request. Use null userId in request.
-     * @return List of authentication methods wrapped in GetAuthMethodResponse.
-     */
-    @RequestMapping(value = "/auth-method/list", method = RequestMethod.POST)
-    public @ResponseBody
-    Response<GetAuthMethodsResponse> getAuthMethods(@RequestBody Request<GetAuthMethodsRequest> request) {
-        GetAuthMethodsRequest requestObject = request.getRequestObject();
-        String userId = requestObject.getUserId();
-        if (userId != null) {
-            throw new IllegalArgumentException("Parameter userId is not null in request object, however null value was expected.");
-        }
-        List<AuthMethodEntity> authMethods = authMethodRepository.findAllAuthMethods();
-        List<AuthMethod> responseList = new ArrayList<>();
-        if (authMethods == null || authMethods.isEmpty()) {
-            throw new IllegalStateException("No authentication method is configured in Next Step server.");
-        }
-        GetAuthMethodsResponse response = new GetAuthMethodsResponse();
-        for (AuthMethodEntity authMethod : authMethods) {
-            responseList.add(authMethod.getAuthMethod());
-        }
-        response.setAuthMethods(responseList);
-        return new Response<>(Response.Status.OK, response);
-    }
-
-    /**
-     * Get all enabled authentication methods for given user.
-     *
-     * @param request Get auth methods request. Use non-null userId in request.
-     * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
-     */
-    @RequestMapping(value = "/user/auth-method/list", method = RequestMethod.POST)
-    public @ResponseBody
-    Response<GetAuthMethodsResponse> getAuthMethodsEnabledForUser(@RequestBody Request<GetAuthMethodsRequest> request) {
-        GetAuthMethodsRequest requestObject = request.getRequestObject();
-        String userId = requestObject.getUserId();
-        if (userId == null) {
-            throw new IllegalArgumentException("Parameter userId is null in request object.");
-        }
-        List<AuthMethod> authMethods = userPrefsService.listAuthMethodsEnabledForUser(userId);
-        GetAuthMethodsResponse response = new GetAuthMethodsResponse();
-        response.setAuthMethods(authMethods);
-        return new Response<>(Response.Status.OK, response);
-    }
-
-    /**
-     * Enable an authentication method for given user.
-     *
-     * @param request Update auth method request. Use non-null userId in request and specify authMethod.
-     * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
-     */
-    @RequestMapping(value = "/user/auth-method", method = RequestMethod.POST)
-    public @ResponseBody
-    Response<GetAuthMethodsResponse> enableAuthMethodForUser(@RequestBody Request<UpdateAuthMethodRequest> request) {
-        UpdateAuthMethodRequest requestObject = request.getRequestObject();
-        String userId = requestObject.getUserId();
-        if (userId == null) {
-            throw new IllegalArgumentException("Parameter userId is null in request object.");
-        }
-        AuthMethod authMethod = requestObject.getAuthMethod();
-        if (authMethod == null) {
-            throw new IllegalArgumentException("Parameter authMethod is null in request object.");
-        }
-        userPrefsService.updateAuthMethodForUser(userId, authMethod, true);
-        List<AuthMethod> authMethods = userPrefsService.listAuthMethodsEnabledForUser(userId);
-        GetAuthMethodsResponse response = new GetAuthMethodsResponse();
-        response.setAuthMethods(authMethods);
-        return new Response<>(Response.Status.OK, response);
-    }
-
-    /**
-     * Disable an authentication method for given user.
-     *
-     * @param request Update auth method request. Use non-null userId in request and specify authMethod.
-     * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
-     */
-    @RequestMapping(value = "/user/auth-method", method = RequestMethod.DELETE)
-    public @ResponseBody
-    Response<GetAuthMethodsResponse> disableAuthMethodForUser(@RequestBody Request<UpdateAuthMethodRequest> request) {
-        UpdateAuthMethodRequest requestObject = request.getRequestObject();
-        String userId = requestObject.getUserId();
-        if (userId == null) {
-            throw new IllegalArgumentException("Parameter userId is null in request object.");
-        }
-        AuthMethod authMethod = requestObject.getAuthMethod();
-        if (authMethod == null) {
-            throw new IllegalArgumentException("Parameter authMethod is null in request object.");
-        }
-        userPrefsService.updateAuthMethodForUser(userId, authMethod, false);
-        List<AuthMethod> authMethods = userPrefsService.listAuthMethodsEnabledForUser(userId);
-        GetAuthMethodsResponse response = new GetAuthMethodsResponse();
-        response.setAuthMethods(authMethods);
-        return new Response<>(Response.Status.OK, response);
     }
 
 }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/AuthMethodEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/AuthMethodEntity.java
@@ -57,6 +57,12 @@ public class AuthMethodEntity implements Serializable {
     @Column(name = "max_auth_fails")
     private Integer maxAuthorizationFailures;
 
+    @Column(name = "has_user_interface")
+    private Boolean hasUserInterface;
+
+    @Column(name = "display_name_key")
+    private String displayNameKey;
+
     public AuthMethod getAuthMethod() {
         return authMethod;
     }
@@ -111,6 +117,22 @@ public class AuthMethodEntity implements Serializable {
 
     public void setMaxAuthorizationFailures(Integer maxAuthorizationFailures) {
         this.maxAuthorizationFailures = maxAuthorizationFailures;
+    }
+
+    public Boolean getHasUserInterface() {
+        return hasUserInterface;
+    }
+
+    public void setHasUserInterface(Boolean hasUserInterface) {
+        this.hasUserInterface = hasUserInterface;
+    }
+
+    public String getDisplayNameKey() {
+        return displayNameKey;
+    }
+
+    public void setDisplayNameKey(String displayNameKey) {
+        this.displayNameKey = displayNameKey;
     }
 
     @Override

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
@@ -22,6 +22,7 @@ import io.getlime.security.powerauth.app.nextstep.repository.model.entity.AuthMe
 import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationEntity;
 import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationHistoryEntity;
 import io.getlime.security.powerauth.app.nextstep.repository.model.entity.StepDefinitionEntity;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.AuthMethodDetail;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.AuthStep;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthResult;
@@ -53,18 +54,18 @@ public class StepResolutionService {
     private IdGeneratorService idGeneratorService;
     private OperationPersistenceService operationPersistenceService;
     private NextStepServerConfiguration nextStepServerConfiguration;
-    private UserPrefsService userPrefsService;
+    private AuthMethodService authMethodService;
     private AuthMethodRepository authMethodRepository;
     private Map<String, List<StepDefinitionEntity>> stepDefinitionsPerOperation;
 
     @Autowired
     public StepResolutionService(StepDefinitionRepository stepDefinitionRepository, OperationPersistenceService operationPersistenceService,
                                  IdGeneratorService idGeneratorService, NextStepServerConfiguration nextStepServerConfiguration,
-                                 UserPrefsService userPrefsService, AuthMethodRepository authMethodRepository) {
+                                 AuthMethodService authMethodService, AuthMethodRepository authMethodRepository) {
         this.operationPersistenceService = operationPersistenceService;
         this.idGeneratorService = idGeneratorService;
         this.nextStepServerConfiguration = nextStepServerConfiguration;
-        this.userPrefsService = userPrefsService;
+        this.authMethodService = authMethodService;
         this.authMethodRepository = authMethodRepository;
         stepDefinitionsPerOperation = new HashMap<>();
         List<String> operationNames = stepDefinitionRepository.findDistinctOperationNames();
@@ -192,9 +193,11 @@ public class StepResolutionService {
      */
     private List<StepDefinitionEntity> filterSteps(String operationName, OperationRequestType operationType, AuthStepResult authStepResult, AuthMethod authMethod, String userId) {
         List<StepDefinitionEntity> stepDefinitions = stepDefinitionsPerOperation.get(operationName);
-        List<AuthMethod> authMethodsAvailableForUser = null;
+        List<AuthMethod> authMethodsAvailableForUser = new ArrayList<>();
         if (userId != null) {
-            authMethodsAvailableForUser = userPrefsService.listAuthMethodsEnabledForUser(userId);
+            for (AuthMethodDetail authMethodDetail : authMethodService.listAuthMethodsEnabledForUser(userId)) {
+                authMethodsAvailableForUser.add(authMethodDetail.getAuthMethod());
+            }
         }
         List<StepDefinitionEntity> filteredStepDefinitions = new ArrayList<>();
         if (stepDefinitions == null) {

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
@@ -82,7 +82,16 @@ public class StepResolutionService {
      */
     public CreateOperationResponse resolveNextStepResponse(CreateOperationRequest request) {
         CreateOperationResponse response = new CreateOperationResponse();
-        response.setOperationId(idGeneratorService.generateOperationId());
+        if (request.getOperationId() != null && !request.getOperationId().isEmpty()) {
+            // operation ID received from the client, verify that it is available
+            if (operationPersistenceService.getOperation(request.getOperationId()) != null) {
+                throw new IllegalArgumentException("Operation could not be created, operation ID is already used: " + request.getOperationId());
+            }
+            response.setOperationId(request.getOperationId());
+        } else {
+            // set auto-generated operation ID
+            response.setOperationId(idGeneratorService.generateOperationId());
+        }
         response.setOperationName(request.getOperationName());
         // AuthStepResult and AuthMethod are not available when creating the operation, null values are used to ignore them
         List<StepDefinitionEntity> stepDefinitions = filterSteps(request.getOperationName(), OperationRequestType.CREATE, null, null, null);

--- a/powerauth-webauth-authentication/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/controller/AuthMethodController.java
+++ b/powerauth-webauth-authentication/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/controller/AuthMethodController.java
@@ -199,17 +199,17 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
             } else {
                 // user was authenticated - complete authorization
                 String operationId = authenticationManagementService.updateAuthenticationWithUserId(userId);
+                // fix of issue #44 - The last authMethod/authResult is shown twice in operation history
+                // first check whether response can be derived from operation detail - the auth method already called authorize()
+                final R authResponseFromOperationDetail = deriveAuthorizationResponseFromOperationDetail(operationId, userId, provider);
+                if (authResponseFromOperationDetail != null) {
+                    // authorization was successfully derived, return response immediately to avoid a duplicate update call
+                    return authResponseFromOperationDetail;
+                }
+                // response could not be derived - call authorize() method to update current operation
                 responseObject = authorize(operationId, userId, null);
             }
             // TODO: Allow passing custom parameters
-            String operationId = authenticationManagementService.updateAuthenticationWithUserId(userId);
-            // fix of issue #44 - The last authMethod/authResult is shown twice in operation history
-            // first check whether response can be derived from operation detail - the auth method already called authorize()
-            final R authResponseFromOperationDetail = deriveAuthorizationResponseFromOperationDetail(operationId, userId, provider);
-            if (authResponseFromOperationDetail!=null) {
-                return authResponseFromOperationDetail;
-            }
-            // response could not be derived - call authorize() method to update current operation
             switch (responseObject.getResult()) {
                 case DONE: {
                     authenticationManagementService.authenticateCurrentSession();

--- a/powerauth-webauth-authentication/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/controller/AuthMethodController.java
+++ b/powerauth-webauth-authentication/src/main/java/io/getlime/security/powerauth/lib/webauth/authentication/controller/AuthMethodController.java
@@ -142,7 +142,7 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
      */
     protected R initiateOperationWithName(String operationName, String operationData, List<KeyValueParameter> params, AuthResponseProvider provider) {
         try {
-            Response<CreateOperationResponse> response = nextStepService.createOperation(operationName, operationData, params);
+            Response<CreateOperationResponse> response = nextStepService.createOperation(operationName, null, operationData, params);
             CreateOperationResponse responseObject = response.getResponseObject();
             String operationId = responseObject.getOperationId();
             authenticationManagementService.createAuthenticationWithOperationId(operationId);

--- a/powerauth-webauth-client/src/main/java/io/getlime/security/powerauth/app/webauth/demo/controller/HomeController.java
+++ b/powerauth-webauth-client/src/main/java/io/getlime/security/powerauth/app/webauth/demo/controller/HomeController.java
@@ -15,13 +15,6 @@
  */
 package io.getlime.security.powerauth.app.webauth.demo.controller;
 
-import java.math.BigDecimal;
-import java.security.Principal;
-
-import javax.inject.Inject;
-import javax.inject.Provider;
-import javax.servlet.http.HttpSession;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.getlime.security.powerauth.app.webauth.demo.model.PaymentForm;
@@ -40,6 +33,12 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.servlet.http.HttpSession;
+import java.math.BigDecimal;
+import java.security.Principal;
 
 /**
  * Default demo controller class.
@@ -112,7 +111,7 @@ public class HomeController {
         messageAttr.setMessage(paymentForm.getNote());
         details.getParameters().add(messageAttr);
 
-        final Response<CreateOperationResponse> payment = client.createOperation("authorize_payment", data, details, null);
+        final Response<CreateOperationResponse> payment = client.createOperation("authorize_payment", null, data, details, null);
         session.setAttribute("operationId", payment.getResponseObject().getOperationId());
 
 

--- a/powerauth-webauth-docs/sql/mysql/create_schema.sql
+++ b/powerauth-webauth-docs/sql/mysql/create_schema.sql
@@ -60,7 +60,9 @@ CREATE TABLE ns_auth_method (
   user_prefs_column  INTEGER,
   user_prefs_default BOOLEAN,
   check_auth_fails   BOOLEAN,
-  max_auth_fails     INTEGER
+  max_auth_fails     INTEGER,
+  has_user_interface BOOLEAN,
+  display_name_key   VARCHAR(32)
 );
 
 CREATE TABLE ns_user_prefs (

--- a/powerauth-webauth-docs/sql/mysql/initial_data.sql
+++ b/powerauth-webauth-docs/sql/mysql/initial_data.sql
@@ -2,16 +2,18 @@ INSERT INTO oauth_client_details (client_id, client_secret, scope, authorized_gr
 VALUES ('democlient', 'changeme', 'profile', 'authorization_code', '{}', 'true');
 
 # authentication methods
-INSERT INTO ns_auth_method (auth_method, order_number, check_user_prefs, user_prefs_column, user_prefs_default, check_auth_fails, max_auth_fails)
-VALUES ('USER_ID_ASSIGN', 1, FALSE, NULL, NULL, FALSE, NULL);
-INSERT INTO ns_auth_method (auth_method, order_number, check_user_prefs, user_prefs_column, user_prefs_default, check_auth_fails, max_auth_fails)
-VALUES ('USERNAME_PASSWORD_AUTH', 2, TRUE, 1, TRUE, TRUE, 5);
-INSERT INTO ns_auth_method (auth_method, order_number, check_user_prefs, user_prefs_column, user_prefs_default, check_auth_fails, max_auth_fails)
-VALUES ('SHOW_OPERATION_DETAIL', 3, FALSE, NULL, NULL, FALSE, NULL);
-INSERT INTO ns_auth_method (auth_method, order_number, check_user_prefs, user_prefs_column, user_prefs_default, check_auth_fails, max_auth_fails)
-VALUES ('POWERAUTH_TOKEN', 4, TRUE, 2, FALSE, TRUE, 1);
-INSERT INTO ns_auth_method (auth_method, order_number, check_user_prefs, user_prefs_column, user_prefs_default, check_auth_fails, max_auth_fails)
-VALUES ('SMS_KEY', 5, FALSE, NULL, NULL, TRUE, 5);
+INSERT INTO ns_auth_method (auth_method, order_number, check_user_prefs, user_prefs_column, user_prefs_default, check_auth_fails, max_auth_fails, has_user_interface, display_name_key)
+VALUES ('INIT', 1, FALSE, NULL, NULL, FALSE, NULL, FALSE, NULL);
+INSERT INTO ns_auth_method (auth_method, order_number, check_user_prefs, user_prefs_column, user_prefs_default, check_auth_fails, max_auth_fails, has_user_interface, display_name_key)
+VALUES ('USER_ID_ASSIGN', 2, FALSE, NULL, NULL, FALSE, NULL, FALSE, NULL);
+INSERT INTO ns_auth_method (auth_method, order_number, check_user_prefs, user_prefs_column, user_prefs_default, check_auth_fails, max_auth_fails, has_user_interface, display_name_key)
+VALUES ('USERNAME_PASSWORD_AUTH', 3, TRUE, 1, TRUE, TRUE, 5, TRUE, 'method.username_password');
+INSERT INTO ns_auth_method (auth_method, order_number, check_user_prefs, user_prefs_column, user_prefs_default, check_auth_fails, max_auth_fails, has_user_interface, display_name_key)
+VALUES ('SHOW_OPERATION_DETAIL', 4, FALSE, NULL, NULL, FALSE, NULL, TRUE, 'method.show_operation_detail');
+INSERT INTO ns_auth_method (auth_method, order_number, check_user_prefs, user_prefs_column, user_prefs_default, check_auth_fails, max_auth_fails, has_user_interface, display_name_key)
+VALUES ('POWERAUTH_TOKEN', 4, TRUE, 5, FALSE, TRUE, 1, TRUE, 'method.powerauth_token');
+INSERT INTO ns_auth_method (auth_method, order_number, check_user_prefs, user_prefs_column, user_prefs_default, check_auth_fails, max_auth_fails, has_user_interface, display_name_key)
+VALUES ('SMS_KEY', 6, FALSE, NULL, NULL, TRUE, 5, TRUE, 'method.sms_key');
 
 # login - init operation -> CONTINUE
 INSERT INTO ns_step_definition (step_definition_id, operation_name, operation_type, request_auth_method, request_auth_step_result, response_priority, response_auth_method, response_result)

--- a/powerauth-webauth/src/main/resources/static/resources/messages_cs.properties
+++ b/powerauth-webauth/src/main/resources/static/resources/messages_cs.properties
@@ -30,3 +30,7 @@ message.invalidRequest=Chybná žádost.
 message.token.confirm = Potvrďte operaci na vašem mobilním zařízení.
 message.token.offline = Nemáte data na mobilním zařízení? Nevadí.
 message.token.offline.link = Potvrďte operaci ověřením přes QR kód.
+method.username_password=Přihlášení
+method.show_operation_detail=Detail operace
+method.powerauth_token=Mobilní token
+method.method.sms_key=SMS klíč

--- a/powerauth-webauth/src/main/resources/static/resources/messages_en.properties
+++ b/powerauth-webauth/src/main/resources/static/resources/messages_en.properties
@@ -30,3 +30,7 @@ message.invalidRequest=Invalid request.
 message.token.confirm = Please confirm the operation on your mobile device.
 message.token.offline = No data on the mobile device? No problem!
 message.token.offline.link = Confirm the operation via the QR code.
+method.username_password=Login
+method.show_operation_detail=Operation Detail
+method.powerauth_token=Mobile Token
+method.method.sms_key=SMS Key


### PR DESCRIPTION
Note that this pull request contains pull requests #69 and #71 because of potential merge conflicts.

It should be possible to use a custom operationId now when creating an operation.

